### PR TITLE
TraceLoop API Key added in Environment setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ SPOTIFY_CLIENT_ID=your_client_id
 SPOTIFY_CLIENT_SECRET=your_client_secret
 OPENAI_API_KEY=your_openai_key
 FLASK_APP_SECRET_KEY=your_secret_key
+TRACELOOP_API_KEY=your_traceloop
 ```
 
 2. Get it running:

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ SPOTIFY_CLIENT_ID=your_client_id
 SPOTIFY_CLIENT_SECRET=your_client_secret
 OPENAI_API_KEY=your_openai_key
 FLASK_APP_SECRET_KEY=your_secret_key
-TRACELOOP_API_KEY=your_traceloop
+TRACELOOP_API_KEY=your_traceloop_key
 ```
 
 2. Get it running:


### PR DESCRIPTION
Added TRACELOOP_API_KEY=your_traceloop, which is required for the environment setup.


Traced from error caused during testing on local:

Warning: Traceloop not initialized, make sure you call Traceloop.init()
Error: Missing Traceloop API key, go to https://app.traceloop.com/settings/api-keys to create one
Set the TRACELOOP_API_KEY environment variable to the key